### PR TITLE
Add pipe for reversed time field translation

### DIFF
--- a/lib/pyper/pipeline.rb
+++ b/lib/pyper/pipeline.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/hash' # indifferent access
+
 require_relative 'write_pipes/cassandra_writer'
 require_relative 'write_pipes/attribute_serializer'
 require_relative 'write_pipes/content_storage'
@@ -16,6 +18,7 @@ require_relative 'read_pipes/force_enumerator'
 require_relative 'pipes/mod_key'
 require_relative 'pipes/field_rename'
 require_relative 'pipes/default_values'
+require_relative 'pipes/translate_reversed_time_field'
 
 module Pyper
 

--- a/lib/pyper/pipes/translate_reversed_time_field.rb
+++ b/lib/pyper/pipes/translate_reversed_time_field.rb
@@ -1,0 +1,40 @@
+module Pyper::Pipes
+  # Cassandra sometimes has issues sorting in descending order, meaning that timestamp fields will not work well
+  # for most-recent-first accessing of data. Instead, we can use a reversed integer field to achieve the same result.
+  # This pipe translates between those two formats.
+  # See https://issues.apache.org/jira/browse/CASSANDRA-7867 for more info.
+  # @param [Array] A list of date fields which should be encoded as reversed (negative) integers
+  class TranslateReversedTimeField
+
+    attr_reader :time_fields
+
+    def initialize(*args)
+      @time_fields = *args
+    end
+
+    # @param [Hash|Enumerator] A set of attrs containing the time field(s) to be encoded, or an Enumerator of items,
+    # each of which has the time field(s) to be decoded.
+    def pipe(attrs_or_items, status = {})
+      case attrs_or_items
+      when Hash then encode(attrs_or_items)
+      else decode(attrs_or_items)
+      end
+    end
+
+    def encode(attrs)
+      time_fields.each do |field|
+        attrs[field] = -attrs[field].to_i if attrs.has_key?(field)
+      end
+      attrs
+    end
+
+    def decode(items)
+      items.map do |item|
+        time_fields.each do |field|
+          item[field] = Time.at(-item[field]) if item.has_key?(field)
+        end
+        item
+      end
+    end
+  end
+end

--- a/lib/pyper/read_pipes/cass_mod_key_enumerator.rb
+++ b/lib/pyper/read_pipes/cass_mod_key_enumerator.rb
@@ -24,7 +24,7 @@ module Pyper::ReadPipes
            result = client.select(table).where(arguments.merge(:mod_key => mod_id)).execute
            result.each { |item| yielder << item }
          end
-       end).lazy
+       end).lazy.map { |item| item.with_indifferent_access }
     end
   end
 end

--- a/lib/pyper/read_pipes/cassandra_items.rb
+++ b/lib/pyper/read_pipes/cassandra_items.rb
@@ -27,7 +27,7 @@ module Pyper::ReadPipes
       status[:paging_state] = result.paging_state
       status[:last_page] = result.last_page?
 
-      result.rows.lazy
+      result.rows.lazy.map { |item| item.with_indifferent_access }
     end
   end
 end

--- a/test/unit/pyper/pipes/translate_reversed_time_field_test.rb
+++ b/test/unit/pyper/pipes/translate_reversed_time_field_test.rb
@@ -1,0 +1,42 @@
+require_relative '../../../test_helper'
+
+module Pyper::Pipes
+  class TranslateReversedTimeFieldTest < Minitest::Should::TestCase
+    context 'the reversed time field pipe' do
+
+      setup do
+        @pipe = TranslateReversedTimeField.new(:time, :time2)
+      end
+
+      context 'encoding attr objects' do
+        should 'encode provided fields' do
+          time = Time.now
+          encoded = -time.to_i
+          assert_equal({ :time => encoded }, @pipe.pipe(:time => time))
+        end
+
+        should 'not encode other fields' do
+          time = Time.now
+          assert_equal({ :other => time }, @pipe.pipe(:other => time))
+        end
+      end
+
+      context 'decoding item lists' do
+        should 'decode time fields' do
+          time = Time.now
+          encoded = -time.to_i
+          decoded_array = @pipe.pipe([{:time => encoded}])
+          assert_equal(1, decoded_array.count)
+          assert_equal(1, decoded_array.first.keys.count)
+          assert_equal(Time, decoded_array.first[:time].class)
+          assert_equal(-encoded, decoded_array.first[:time].to_i)
+        end
+
+        should 'not decode other fields' do
+          encoded = -1
+          assert_equal([{:other => encoded}], @pipe.pipe([{:other => encoded}]))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Because of https://issues.apache.org/jira/browse/CASSANDRA-7867,
sorting in descending order does not always work correctly in cassandra.
A common case where this arises is when a row is intended to be ordered
in most recent-first order using a timestamp column. This adds a
workaround for this case that translates Time fields to negative
integers, so that an ascending ordering will return most recent first.

Additionally, modifies the CassandraItems and CassModKeyEnumerator pipes
to return items with indifferent access, so that field lookup by symbol
will work properly.
