### PR TITLE
add Pipeline::create and Pipeline#add

### DIFF
--- a/lib/pyper/pipeline.rb
+++ b/lib/pyper/pipeline.rb
@@ -24,7 +24,16 @@ module Pyper
   class PipeStatus < Struct.new(:value, :status); end
 
   class Pipeline
+    class << self
+      def create
+        new.tap do |pl|
+          pl.instance_eval &Proc.new if block_given?
+        end
+      end
+    end
+
     attr_reader :pipes
+
     def initialize(pipes = [])
       @pipes = pipes
     end
@@ -34,6 +43,8 @@ module Pyper
       pipes << pipe
       self
     end
+
+    alias_method :add, :<<
 
     # Insert something into the pipeline to be processed
     # @param [Object] The original input data to enter the pipeline. This may be mutated by each pipe in the pipeline.

--- a/test/unit/pyper/pipeline_test.rb
+++ b/test/unit/pyper/pipeline_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+module Pyper
+  class PipelineTest < Minitest::Should::TestCase
+    context '::create' do
+      context 'with a block' do
+        should 'yield the instance to the block' do
+          el = 'hello'
+
+          pl = Pyper::Pipeline.create do
+            add el
+          end
+
+          assert pl.pipes.include? el
+        end
+
+        should 'return a new pipeline' do
+          pl = Pyper::Pipeline.create do
+            add 'hello'
+          end
+
+          assert pl.is_a? Pyper::Pipeline
+        end
+      end
+
+      context 'without a block' do
+        should 'return a new pipeline' do
+          pl = Pyper::Pipeline.create
+
+          assert pl.is_a? Pyper::Pipeline
+        end
+      end
+    end
+
+    context '#add' do
+      should 'add the pipe to the pipes' do
+        pl = Pyper::Pipeline.new
+        el = 'hello'
+        pl.add el
+
+        assert pl.pipes.include? el
+      end
+    end
+  end
+end


### PR DESCRIPTION
Simple DSL method for cleaning up the instantiation of a pipeline.

So far we've done this the following ways:

``` rb
# Jagged call chaining
pl = Pyper::Pipeline.new <<
  PipeOne <<
  PipeTwo

# Saving to var
pl = Pyper::Pipeline.new
pl << PipeOne
pl << PipeTwo
```

This PR adds a third way which I find a little cleaner (albeit more magical):

``` rb
# DSL method
pl = Pyper::Pipeline.create do
  add PipeOne
  add PipeTwo
end
```
