### PR TITLE
Allow methods to be called from within the #create block.

### DIFF
--- a/test/unit/pyper/pipeline_test.rb
+++ b/test/unit/pyper/pipeline_test.rb
@@ -14,6 +14,18 @@ module Pyper
           assert pl.pipes.include? el
         end
 
+        should 'allow access to externally defined methods' do
+          def external
+            'external'
+          end
+
+          pl = Pyper::Pipeline.create do
+            add external
+          end
+
+          assert pl.pipes.include? external
+        end
+
         should 'return a new pipeline' do
           pl = Pyper::Pipeline.create do
             add 'hello'


### PR DESCRIPTION
Allows methods to be called from within the Pipeline#create block. Similar
implementation to that used in https://github.com/backupify/data_filter.