### PR TITLE
Rename gem to pyper_rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ end
 
 This example pipe above modifies `attributes` before returning it. It also sets a flag on the status object.
 
-Note that because the pipe need only respond to `call`, lambdas and procs are valid pipes. 
+Note that because the pipe need only respond to `call`, lambdas and procs are valid pipes.
 
 Generally, pipes in a write pipeline operate on an attributes hash (containing the attributes meant to be written to a data
 store). Pipes in a read pipeline initially might modify arguments. A data retrieval pipe would then use the arguments to
@@ -135,7 +135,7 @@ end
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'pyper', :git => 'git@github.com:backupify/pyper.git'
+gem 'pyper_rb', :git => 'git@github.com:backupify/pyper.git'
 ```
 
 And then execute:
@@ -144,7 +144,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install pyper
+    $ gem install pyper_rb
 
 ## Contributing
 

--- a/pyper_rb.gemspec
+++ b/pyper_rb.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'pyper/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "pyper"
+  spec.name          = "pyper_rb"
   spec.version       = Pyper::VERSION
   spec.authors       = ["Arron Norwell"]
   spec.email         = ["anorwell@datto.com"]


### PR DESCRIPTION
The gem 'pyper' already exists on RubyGems. This renames the gem to
pyper_rb, without renaming any of the library modules.