### PR TITLE
ttl support

### DIFF
--- a/lib/pyper/pipes/cassandra/writer.rb
+++ b/lib/pyper/pipes/cassandra/writer.rb
@@ -17,7 +17,8 @@ module Pyper::Pipes::Cassandra
                               attributes
                             end
 
-      client.insert(table_name, attributes_to_write)
+      ttl = attributes_to_write.delete(:ttl)
+      client.insert(table_name, attributes_to_write, ttl)
       attributes
     end
   end

--- a/lib/pyper/version.rb
+++ b/lib/pyper/version.rb
@@ -1,3 +1,3 @@
 module Pyper
-  VERSION = "1.5.0"
+  VERSION = "1.5.1"
 end

--- a/test/unit/pyper/pipes/cassandra/writer_test.rb
+++ b/test/unit/pyper/pipes/cassandra/writer_test.rb
@@ -46,6 +46,18 @@ module Pyper::Pipes::Cassandra
         writer = Writer.new(:test, @client, filter)
         assert_equal attributes, writer.pipe(attributes)
       end
+
+      should 'allow a TTL to be passed into the pipe' do
+        attributes = {id: 'id', a: 'a', b: 'b', ttl: 12345}
+        filter = [:id, :a, :b, :ttl]
+        ttl = attributes[:ttl]
+        expected_attributes = attributes.dup
+        expected_attributes.delete(:ttl)
+
+        writer = Writer.new(:test, @client, filter)
+        writer.client.expects(:insert).with(:test, expected_attributes, ttl)
+        assert_equal attributes, writer.pipe(attributes)
+      end
     end
   end
 end


### PR DESCRIPTION
allows ttls to be passed into the write pipe, as part of our effort to support ttls for docs CDR.  will need to be updated after the changes to the cassava gem, which allows the optional ttl argument to be passed into the insert call.  also will be meaningless until some changes are made to the storage metadata index adapter code which should include ttls as an acceptable attribute to be passed in. part of the steps required for http://jira.datto.lan/browse/BFY-2350 and for all services cdr ability in the future