### PR TITLE
add comparator functionality

### DIFF
--- a/lib/pyper/pipes/cassandra/reader.rb
+++ b/lib/pyper/pipes/cassandra/reader.rb
@@ -21,7 +21,6 @@ module Pyper::Pipes::Cassandra
       columns = arguments.delete(:columns)
       consistency = arguments.delete(:consistency)
       where = arguments.delete(:where)
-      allow_filtering = arguments.delete(:allow_filtering)
 
       opts = options.nil? ? {} : options.dup
       opts[:page_size] = page_size if page_size
@@ -34,7 +33,6 @@ module Pyper::Pipes::Cassandra
 
       query = query.limit(limit) if limit
       query = query.order(order.first, order.last) if order
-      query = query.allow_filtering if allow_filtering
       result = query.execute(opts)
 
       status[:paging_state] = result.paging_state

--- a/lib/pyper/pipes/cassandra/reader.rb
+++ b/lib/pyper/pipes/cassandra/reader.rb
@@ -21,6 +21,7 @@ module Pyper::Pipes::Cassandra
       columns = arguments.delete(:columns)
       consistency = arguments.delete(:consistency)
       where = arguments.delete(:where)
+      allow_filtering = arguments.delete(:allow_filtering)
 
       opts = options.nil? ? {} : options.dup
       opts[:page_size] = page_size if page_size
@@ -33,7 +34,7 @@ module Pyper::Pipes::Cassandra
 
       query = query.limit(limit) if limit
       query = query.order(order.first, order.last) if order
-
+      query = query.allow_filtering if allow_filtering
       result = query.execute(opts)
 
       status[:paging_state] = result.paging_state

--- a/lib/pyper/pipes/cassandra/reader.rb
+++ b/lib/pyper/pipes/cassandra/reader.rb
@@ -20,17 +20,16 @@ module Pyper::Pipes::Cassandra
       order = arguments.delete(:order)
       columns = arguments.delete(:columns)
       consistency = arguments.delete(:consistency)
-
-      # arguments to be searched by < and >
-      comparators = arguments.delete(:comparators)
+      where = arguments.delete(:where)
 
       opts = options.nil? ? {} : options.dup
       opts[:page_size] = page_size if page_size
       opts[:paging_state] = paging_state if paging_state
       opts[:consistency] = consistency if consistency
 
-      query = client.select(table, columns).where(arguments)
-      query = query.where(comparators)
+      query = client.select(table, columns)
+      query = query.where(arguments) if arguments.any? # backwards-compatibility -- it should be preferred to pass in `:where`
+      where.each { |clause| query = query.where(*clause) } if where.present?
 
       query = query.limit(limit) if limit
       query = query.order(order.first, order.last) if order

--- a/lib/pyper/pipes/cassandra/reader.rb
+++ b/lib/pyper/pipes/cassandra/reader.rb
@@ -21,12 +21,17 @@ module Pyper::Pipes::Cassandra
       columns = arguments.delete(:columns)
       consistency = arguments.delete(:consistency)
 
+      # arguments to be searched by < and >
+      comparators = arguments.delete(:comparators)
+
       opts = options.nil? ? {} : options.dup
       opts[:page_size] = page_size if page_size
       opts[:paging_state] = paging_state if paging_state
       opts[:consistency] = consistency if consistency
 
       query = client.select(table, columns).where(arguments)
+      query = query.where(comparators)
+
       query = query.limit(limit) if limit
       query = query.order(order.first, order.last) if order
 

--- a/lib/pyper/version.rb
+++ b/lib/pyper/version.rb
@@ -1,3 +1,3 @@
 module Pyper
-  VERSION = "1.5.0"
+  VERSION = "1.5.1"
 end

--- a/test/unit/pyper/pipes/cassandra/reader_test.rb
+++ b/test/unit/pyper/pipes/cassandra/reader_test.rb
@@ -35,6 +35,11 @@ module Pyper::Pipes::Cassandra
         assert_equal 1, out.count
       end
 
+      should 'support where clauses' do
+        out = @pipe.pipe(where: [['id = ?', 'id'], ['a = ?', '1']]).to_a
+        assert_equal 1, out.count
+      end
+
       should 'order results by field and direction if order pair provided' do
         out = @pipe.pipe(id: 'id', :order => [:a, :desc]).to_a
         assert_equal %w(2 1), out.map { |i| i['a'] }

--- a/test/unit/pyper/pipes/cassandra/reader_test.rb
+++ b/test/unit/pyper/pipes/cassandra/reader_test.rb
@@ -36,8 +36,9 @@ module Pyper::Pipes::Cassandra
       end
 
       should 'support where clauses' do
-        out = @pipe.pipe(where: [['id = ?', 'id'], ['a = ?', '1']]).to_a
+        out = @pipe.pipe(where: [['id = ?', 'id'], ['a > ?', '1']]).to_a
         assert_equal 1, out.count
+        assert_equal '2', out.first['a']
       end
 
       should 'order results by field and direction if order pair provided' do


### PR DESCRIPTION
adds the ability to pass through an array of comparators so that results can be filtered using `<` and `>`.